### PR TITLE
relay system example (not sure)  <3

### DIFF
--- a/servermanager/relay.go
+++ b/servermanager/relay.go
@@ -1,0 +1,99 @@
+package relay
+
+import (
+	"log"
+	"net"
+	"sync"
+
+	. "github.com/KouKouChan/CSO2-Server/blademaster/typestruct"
+	. "github.com/KouKouChan/CSO2-Server/kerlong"
+	. "github.com/KouKouChan/CSO2-Server/verbose"
+)
+
+// TestListenForConnections tests for network and port
+func TestListenForConnections(t *testing.T) {
+	tables := []struct {
+		port int
+	}{
+		{8080},
+		{9090},
+	}
+	for _, table := range tables {
+		listener := listenForConnections(table.port)
+		defer listener.Close()
+
+		if address := listener.Addr().String(); strings.HasSuffix(address, strconv.Itoa(table.port)) == false {
+			t.Errorf("Port not as expected, got: %s, want: %s.", address, strconv.Itoa(table.port))
+		}
+	}
+}
+
+// TestListenForConnectionsPanic tests for panic if port in use
+func TestListenForConnectionsPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	listener1 := listenForConnections(9990)
+	listener2 := listenForConnections(9990)
+	listener1.Close()
+	listener2.Close()
+
+}
+
+// TestAcceptConnections tests for multiple connections per listener
+// Currently the worst test :)
+func TestAcceptConnections(t *testing.T) {
+	wg := sync.WaitGroup{}
+	listener := listenForConnections(31331)
+	defer listener.Close()
+	go func() {
+		conn := acceptConnections(listener)
+		defer conn.Close()
+		fmt.Println(conn.RemoteAddr())
+	}()
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			conn, err := net.Dial("tcp", ":31331")
+			defer conn.Close()
+			if err != nil {
+				t.Errorf("Was expecting no errors in accepting multiple dials. %s", err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestEcho makes a system level end to end test.
+func TestEcho(t *testing.T) {
+	message := []byte("testing123")
+	regPort := 8080
+
+	go RunTCPServer(regPort, 1)
+	go echo.Run()
+	// Give some time for the setup
+	time.Sleep(time.Second / 200)
+
+	conn, err := net.DialTCP("tcp", nil, &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: regPort + 1,
+		Zone: "",
+	})
+	if err != nil {
+		t.Errorf("Connection failed, was expecting success on port %d. %s", regPort+1, err)
+	}
+	defer conn.Close()
+	conn.Write(message)
+	buf := make([]byte, 10, 10)
+	conn.Read(buf)
+	for i, char := range message {
+		if char == buf[i] {
+			continue
+		}
+		t.Errorf("Echo is not working, got: %s, want: %s", buf, message)
+	}
+}


### PR DESCRIPTION
The system logic is: the ip addresses of the opened rooms should only be opened with the ports on the main server, the files are read through the client
1st Room Established
2.Set the server IP: 8111 OR a DIFFERENT port
for example, it is installed to the address assigned to you by RAdmin. Room is set up on server ports in this system.
3. When the game starts, all players can enter without vpn, but can be turned off when the room founder leaves.
please view this topic <3
best server <3 KouKouChan <3