### PR TITLE
faulty or missing chat functionality

### DIFF
--- a/blademaster/core/chat/channelMessage .go
+++ b/blademaster/core/chat/channelMessage .go
@@ -57,5 +57,6 @@ func OnChatChannelMessage(p *InChatPacket, client net.Conn) {
 }
 
 func BuildChannelMessage(u *User, p *InChatPacket) []byte {
-	return BytesCombine([]byte("["+GAME_CHANNEL_MESSAGE+"] "+u.UserName+" : "), p.Message)
+	// when this command channel is selected, no one but you can see the words you type in the chat - unnecessary use or repair
+	// return BytesCombine([]byte("["+GAME_CHANNEL_MESSAGE+"] "+u.UserName+" : "), p.Message)
 }


### PR DESCRIPTION
No one can see what you type unless you create a room in the lobby. - We did 4 user tests and none of us saw our own messages. Typed texts are only shown to the user himself.
or fix this bug in helgacore